### PR TITLE
Remove zombie code

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -11,8 +11,6 @@ int main(int argc, char *argv[])
     if (pos != std::string::npos)
         path = '"' + s.substr(0,pos+1) + "config.bat" + '"';
 
-    //std::cout<<path<<std::endl;
-
     for (int i=1; i<argc; i++)
         path+=" "+std::string(argv[i]);
 


### PR DESCRIPTION
It is generally bad praxis to have commented-out code as it fills no function and adds unnecessary noise, so this pull request removes it from main.cpp.